### PR TITLE
[1.20.1] Allow double-tapping a hotbar slot key to swap just the item in that hotbar slot

### DIFF
--- a/src/main/java/dev/denwav/extendedhotbar/ModConfig.java
+++ b/src/main/java/dev/denwav/extendedhotbar/ModConfig.java
@@ -31,6 +31,9 @@ public class ModConfig implements ConfigData {
     public boolean invert = false;
 
     @ConfigEntry.Gui.Tooltip
+    public boolean enableDoubleTap = false;
+
+    @ConfigEntry.Gui.Tooltip
     public boolean enableModifier = false;
 
     @ConfigEntry.Gui.Tooltip

--- a/src/main/java/dev/denwav/extendedhotbar/mixin/MixinMinecraftClient.java
+++ b/src/main/java/dev/denwav/extendedhotbar/mixin/MixinMinecraftClient.java
@@ -17,6 +17,7 @@
 
 package dev.denwav.extendedhotbar.mixin;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import dev.denwav.extendedhotbar.Util;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -29,6 +30,7 @@ import net.minecraft.item.Item;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -97,6 +99,22 @@ public class MixinMinecraftClient {
             }
             Util.performSwap((MinecraftClient) (Object) this, true);
             break;
+        }
+    }
+
+    @Inject(
+            method = "handleInputEvents",
+            at = @At(
+                    value = "FIELD",
+                    target = "Lnet/minecraft/entity/player/PlayerInventory;selectedSlot:I",
+                    opcode = Opcodes.PUTFIELD
+            )
+    )
+    private void handleInputEvents(CallbackInfo ci, @Local(ordinal = 0) int loopIndex) {
+        if (!Util.configHolder.getConfig().enableDoubleTap) return;
+
+        if (this.player.getInventory().selectedSlot == loopIndex) {
+            Util.performSwap((MinecraftClient) (Object) this, false);
         }
     }
 }

--- a/src/main/resources/assets/extendedhotbar/lang/en_us.json
+++ b/src/main/resources/assets/extendedhotbar/lang/en_us.json
@@ -7,6 +7,8 @@
   "text.autoconfig.extendedhotbar.option.enabled.@Tooltip": "Toggle Extended Hotbar on and off",
   "text.autoconfig.extendedhotbar.option.invert": "Invert full row / single item swap",
   "text.autoconfig.extendedhotbar.option.invert.@Tooltip": "Invert full row / single item swap",
+  "text.autoconfig.extendedhotbar.option.enableDoubleTap": "Enable double-tap to swap",
+  "text.autoconfig.extendedhotbar.option.enableDoubleTap.@Tooltip": "Enable double-tapping a hotbar slot key to swap only that hotbar slot",
   "text.autoconfig.extendedhotbar.option.enableModifier": "Enable shift modifier key",
   "text.autoconfig.extendedhotbar.option.enableModifier.@Tooltip": "Enable holding shift to change item swap behavior",
   "text.autoconfig.extendedhotbar.option.fluent": "Enable fluent mode (disables manual swapping)",


### PR DESCRIPTION
For example, to swap just the item in the 7th hotbar slot, the player could just press the "7" key twice (with default keybinds). This is similar to the original [Dual Hotbar](https://www.curseforge.com/minecraft/mc-mods/dual-hotbar) mod.